### PR TITLE
Add interactive wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ will produce a draft continuation.
 - Python 3.10+
 - `ebooklib` for reading EPUB files
 - `openai` for LLM and embeddings
+- `anthropic` for optional Anthropic LLM support
 - `numpy` for simple similarity search
 
 The repository provides a `requirements.txt` file containing these
@@ -21,7 +22,18 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python -m ghostwriter.cli book1.epub book2.epub --prompt "Short outline" --out next_book.txt
+python -m ghostwriter.cli path/to/epubs --prompt "Short outline" --provider anthropic --out next_book.txt
 ```
 
-The resulting text is saved to `next_book.txt`.
+The resulting text is saved to `next_book.txt`. Specify directories instead of individual files to process all `.epub` files within. Use `--provider` (`openai` or `anthropic`) and `--model` to select the language model. After generation the estimated API cost is printed.
+
+## Interactive wrapper
+
+Run the interactive helper to be prompted for all required options:
+
+```bash
+python -m ghostwriter.wrapper
+```
+
+The wrapper will ask for EPUB locations, your outline, provider, and model, then
+save the generated text and show the estimated API cost.

--- a/ghostwriter/__init__.py
+++ b/ghostwriter/__init__.py
@@ -3,5 +3,6 @@
 __version__ = "0.1.0"
 
 from .cli import main
+from .wrapper import main as interactive
 
-__all__ = ["main"]
+__all__ = ["main", "interactive"]

--- a/ghostwriter/cli.py
+++ b/ghostwriter/cli.py
@@ -18,24 +18,49 @@ def _load_dependencies():
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Ghostwriter CLI")
-    parser.add_argument("epub_files", nargs="+", help="Paths to existing book EPUB files")
+    parser.add_argument(
+        "epub_inputs",
+        nargs="+",
+        help="Paths to existing book EPUB files or directories containing them",
+    )
     parser.add_argument("--prompt", required=True, help="Outline or guidance for next book")
     parser.add_argument("--out", default="next_book.txt", help="Output text filename")
     parser.add_argument("--chapters", type=int, default=10, help="Number of chapters to generate")
+    parser.add_argument(
+        "--provider",
+        choices=["openai", "anthropic"],
+        default="openai",
+        help="LLM provider to use",
+    )
+    parser.add_argument("--model", help="Specific model name to use")
     args = parser.parse_args(argv)
 
     chapters = []
     VectorStore, generate_next_book = _load_dependencies()
     store = VectorStore()
-    for book_path in args.epub_files:
-        texts = read_epub(book_path)
-        chapters.extend(texts)
-        store.add_texts(texts)
+    def _gather_epubs(path: Path) -> list[Path]:
+        if path.is_dir():
+            return sorted(path.glob("*.epub"))
+        return [path]
 
-    generated = generate_next_book(chapters, args.prompt, store, chapters=args.chapters)
+    for path_str in args.epub_inputs:
+        for book_path in _gather_epubs(Path(path_str)):
+            texts = read_epub(str(book_path))
+            chapters.extend(texts)
+            store.add_texts(texts)
+
+    generated, cost = generate_next_book(
+        chapters,
+        args.prompt,
+        store,
+        chapters=args.chapters,
+        provider=args.provider,
+        model=args.model,
+    )
 
     Path(args.out).write_text(generated, encoding="utf-8")
     print(f"Book saved as {args.out}")
+    print(f"Estimated cost: ${cost:.4f}")
 
 
 if __name__ == "__main__":

--- a/ghostwriter/llm.py
+++ b/ghostwriter/llm.py
@@ -2,26 +2,89 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 try:
     import openai
 except ImportError:  # pragma: no cover - optional dependency
     openai = None
 
+try:  # pragma: no cover - optional dependency
+    import anthropic
+except ImportError:
+    anthropic = None
 
-MODEL = "gpt-4"
+
+DEFAULT_MODELS = {"openai": "gpt-4", "anthropic": "claude-v1"}
+# Rough cost per 1k tokens (input/output) for example models
+COST_PER_1K = {
+    "openai": {"gpt-4": {"input": 0.03, "output": 0.06}},
+    "anthropic": {"claude-v1": {"input": 0.008, "output": 0.024}},
+}
 
 
-def summarize_text(text: str) -> str:
-    """Return a short summary of the given text using the LLM."""
+def _count_tokens(text: str) -> int:
+    """Very rough token estimator based on whitespace."""
+    return max(1, len(text.split()))
+
+
+def _estimate_cost(prompt_tokens: int, completion_tokens: int, provider: str, model: str) -> float:
+    info = COST_PER_1K.get(provider, {}).get(model)
+    if info is None:
+        return 0.0
+    return (
+        prompt_tokens * info["input"] / 1000
+        + completion_tokens * info["output"] / 1000
+    )
+
+
+def _call_openai(prompt: str, model: str) -> Tuple[str, int, int]:
     if openai is None:
         raise ImportError("openai package is required for LLM calls")
     response = openai.ChatCompletion.create(
-        model=MODEL,
-        messages=[{"role": "user", "content": f"Summarize the following:\n{text}"}],
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
     )
-    return response["choices"][0]["message"]["content"].strip()
+    content = response["choices"][0]["message"]["content"].strip()
+    usage = response.get("usage", {})
+    prompt_tokens = usage.get("prompt_tokens", _count_tokens(prompt))
+    completion_tokens = usage.get("completion_tokens", _count_tokens(content))
+    return content, prompt_tokens, completion_tokens
+
+
+def _call_anthropic(prompt: str, model: str) -> Tuple[str, int, int]:
+    if anthropic is None:
+        raise ImportError("anthropic package is required for LLM calls")
+    client = anthropic.Client()
+    full_prompt = f"{anthropic.HUMAN_PROMPT} {prompt}{anthropic.AI_PROMPT}"
+    resp = client.completions.create(
+        model=model,
+        prompt=full_prompt,
+        max_tokens_to_sample=1000,
+    )
+    content = resp["completion"].strip()
+    # anthropic API may not return token counts; approximate
+    prompt_tokens = _count_tokens(prompt)
+    completion_tokens = _count_tokens(content)
+    return content, prompt_tokens, completion_tokens
+
+
+def _call_model(prompt: str, provider: str, model: str) -> Tuple[str, int, int]:
+    if provider == "openai":
+        return _call_openai(prompt, model)
+    if provider == "anthropic":
+        return _call_anthropic(prompt, model)
+    raise ValueError(f"Unknown provider: {provider}")
+
+
+def summarize_text(text: str, provider: str = "openai", model: str | None = None) -> Tuple[str, float]:
+    """Return a short summary of the given text using the selected LLM."""
+    model = model or DEFAULT_MODELS[provider]
+    content, p_tokens, c_tokens = _call_model(
+        f"Summarize the following:\n{text}", provider, model
+    )
+    cost = _estimate_cost(p_tokens, c_tokens, provider, model)
+    return content, cost
 
 
 def generate_next_book(
@@ -29,11 +92,19 @@ def generate_next_book(
     guidance: str,
     vector_store,
     chapters: int = 10,
-) -> str:
+    provider: str = "openai",
+    model: str | None = None,
+) -> Tuple[str, float]:
     """Generate a new book continuation given existing texts and guidance."""
-    if openai is None:
-        raise ImportError("openai package is required for LLM calls")
-    summaries = [summarize_text(t) for t in existing_texts]
+    model = model or DEFAULT_MODELS[provider]
+
+    summaries = []
+    total_cost = 0.0
+    for t in existing_texts:
+        summary, cost = summarize_text(t, provider, model)
+        summaries.append(summary)
+        total_cost += cost
+
     context = "\n".join(summaries)
     prompt = (
         "You are the author continuing this saga. Keep tone and world consistent.\n"
@@ -41,8 +112,7 @@ def generate_next_book(
         f"Context from previous books: {context}\n"
         f"Write {chapters} chapters."
     )
-    response = openai.ChatCompletion.create(
-        model=MODEL,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    return response["choices"][0]["message"]["content"].strip()
+
+    content, p_tokens, c_tokens = _call_model(prompt, provider, model)
+    total_cost += _estimate_cost(p_tokens, c_tokens, provider, model)
+    return content, total_cost

--- a/ghostwriter/wrapper.py
+++ b/ghostwriter/wrapper.py
@@ -1,0 +1,59 @@
+"""Interactive wrapper for Ghostwriter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .parser import read_epub
+from .cli import _load_dependencies
+from .llm import DEFAULT_MODELS
+
+
+def _gather_epubs(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(path.glob("*.epub"))
+    return [path]
+
+
+def main() -> None:
+    """Run interactive prompts to generate a new book."""
+    print("Ghostwriter interactive wrapper")
+
+    raw_inputs = input(
+        "Enter path(s) to EPUB files or directories (comma separated): "
+    ).strip()
+    epub_paths = [p.strip() for p in raw_inputs.split(",") if p.strip()]
+    guidance = input("Enter outline/guidance for the next book: ").strip()
+    chapters_str = input("Number of chapters [10]: ").strip()
+    chapters = int(chapters_str) if chapters_str else 10
+    provider = input("LLM provider (openai/anthropic) [openai]: ").strip() or "openai"
+    suggested = DEFAULT_MODELS.get(provider, "gpt-4")
+    print(f"Suggested model: {suggested}")
+    model = input(f"Model name [{suggested}]: ").strip() or suggested
+    out_file = input("Output filename [next_book.txt]: ").strip() or "next_book.txt"
+
+    VectorStore, generate_next_book = _load_dependencies()
+    store = VectorStore()
+    chapters_text = []
+    for path_str in epub_paths:
+        for book_path in _gather_epubs(Path(path_str)):
+            texts = read_epub(str(book_path))
+            chapters_text.extend(texts)
+            store.add_texts(texts)
+
+    generated, cost = generate_next_book(
+        chapters_text,
+        guidance,
+        store,
+        chapters=chapters,
+        provider=provider,
+        model=model,
+    )
+
+    Path(out_file).write_text(generated, encoding="utf-8")
+    print(f"Book saved as {out_file}")
+    print(f"Estimated cost: ${cost:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ebooklib
 openai
+anthropic
 numpy


### PR DESCRIPTION
## Summary
- add an interactive `ghostwriter.wrapper` module
- re-export the interactive entrypoint from `__init__.py`
- document the new wrapper usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683cfbd11aac83268b4ddfaf1c499264