### PR TITLE
Add interactive wrapper and EPUB parsing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ will produce a draft continuation.
 - Python 3.10+
 - `ebooklib` for reading EPUB files
 - `openai` for LLM and embeddings
+- `anthropic` for optional Anthropic LLM support
 - `numpy` for simple similarity search
 
 The repository provides a `requirements.txt` file containing these
@@ -21,7 +22,17 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python -m ghostwriter.cli book1.epub book2.epub --prompt "Short outline" --out next_book.txt
+python -m ghostwriter.cli path/to/epubs --prompt "Short outline" --provider anthropic --out next_book.txt
 ```
 
-The resulting text is saved to `next_book.txt`.
+The resulting text is saved to `next_book.txt`. Specify directories instead of individual files to process all `.epub` files within. Use `--provider` (`openai` or `anthropic`) and `--model` to select the language model. After generation the estimated API cost is printed.
+
+For an interactive experience, run:
+
+```bash
+python -m ghostwriter.wrapper
+```
+
+The wrapper will prompt for the EPUB paths, outline, provider, model, and output
+file, then print the estimated cost after generation.
+

--- a/ghostwriter/__init__.py
+++ b/ghostwriter/__init__.py
@@ -3,5 +3,6 @@
 __version__ = "0.1.0"
 
 from .cli import main
+from .wrapper import main as interactive
 
-__all__ = ["main"]
+__all__ = ["main", "interactive"]

--- a/ghostwriter/cli.py
+++ b/ghostwriter/cli.py
@@ -18,24 +18,49 @@ def _load_dependencies():
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Ghostwriter CLI")
-    parser.add_argument("epub_files", nargs="+", help="Paths to existing book EPUB files")
+    parser.add_argument(
+        "epub_inputs",
+        nargs="+",
+        help="Paths to existing book EPUB files or directories containing them",
+    )
     parser.add_argument("--prompt", required=True, help="Outline or guidance for next book")
     parser.add_argument("--out", default="next_book.txt", help="Output text filename")
     parser.add_argument("--chapters", type=int, default=10, help="Number of chapters to generate")
+    parser.add_argument(
+        "--provider",
+        choices=["openai", "anthropic"],
+        default="openai",
+        help="LLM provider to use",
+    )
+    parser.add_argument("--model", help="Specific model name to use")
     args = parser.parse_args(argv)
 
     chapters = []
     VectorStore, generate_next_book = _load_dependencies()
     store = VectorStore()
-    for book_path in args.epub_files:
-        texts = read_epub(book_path)
-        chapters.extend(texts)
-        store.add_texts(texts)
+    def _gather_epubs(path: Path) -> list[Path]:
+        if path.is_dir():
+            return sorted(path.glob("*.epub"))
+        return [path]
 
-    generated = generate_next_book(chapters, args.prompt, store, chapters=args.chapters)
+    for path_str in args.epub_inputs:
+        for book_path in _gather_epubs(Path(path_str)):
+            texts = read_epub(str(book_path))
+            chapters.extend(texts)
+            store.add_texts(texts)
+
+    generated, cost = generate_next_book(
+        chapters,
+        args.prompt,
+        store,
+        chapters=args.chapters,
+        provider=args.provider,
+        model=args.model,
+    )
 
     Path(args.out).write_text(generated, encoding="utf-8")
     print(f"Book saved as {args.out}")
+    print(f"Estimated cost: ${cost:.4f}")
 
 
 if __name__ == "__main__":

--- a/ghostwriter/llm.py
+++ b/ghostwriter/llm.py
@@ -2,26 +2,89 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 try:
     import openai
 except ImportError:  # pragma: no cover - optional dependency
     openai = None
 
+try:  # pragma: no cover - optional dependency
+    import anthropic
+except ImportError:
+    anthropic = None
 
-MODEL = "gpt-4"
+
+DEFAULT_MODELS = {"openai": "gpt-4", "anthropic": "claude-v1"}
+# Rough cost per 1k tokens (input/output) for example models
+COST_PER_1K = {
+    "openai": {"gpt-4": {"input": 0.03, "output": 0.06}},
+    "anthropic": {"claude-v1": {"input": 0.008, "output": 0.024}},
+}
 
 
-def summarize_text(text: str) -> str:
-    """Return a short summary of the given text using the LLM."""
+def _count_tokens(text: str) -> int:
+    """Very rough token estimator based on whitespace."""
+    return max(1, len(text.split()))
+
+
+def _estimate_cost(prompt_tokens: int, completion_tokens: int, provider: str, model: str) -> float:
+    info = COST_PER_1K.get(provider, {}).get(model)
+    if info is None:
+        return 0.0
+    return (
+        prompt_tokens * info["input"] / 1000
+        + completion_tokens * info["output"] / 1000
+    )
+
+
+def _call_openai(prompt: str, model: str) -> Tuple[str, int, int]:
     if openai is None:
         raise ImportError("openai package is required for LLM calls")
     response = openai.ChatCompletion.create(
-        model=MODEL,
-        messages=[{"role": "user", "content": f"Summarize the following:\n{text}"}],
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
     )
-    return response["choices"][0]["message"]["content"].strip()
+    content = response["choices"][0]["message"]["content"].strip()
+    usage = response.get("usage", {})
+    prompt_tokens = usage.get("prompt_tokens", _count_tokens(prompt))
+    completion_tokens = usage.get("completion_tokens", _count_tokens(content))
+    return content, prompt_tokens, completion_tokens
+
+
+def _call_anthropic(prompt: str, model: str) -> Tuple[str, int, int]:
+    if anthropic is None:
+        raise ImportError("anthropic package is required for LLM calls")
+    client = anthropic.Client()
+    full_prompt = f"{anthropic.HUMAN_PROMPT} {prompt}{anthropic.AI_PROMPT}"
+    resp = client.completions.create(
+        model=model,
+        prompt=full_prompt,
+        max_tokens_to_sample=1000,
+    )
+    content = resp["completion"].strip()
+    # anthropic API may not return token counts; approximate
+    prompt_tokens = _count_tokens(prompt)
+    completion_tokens = _count_tokens(content)
+    return content, prompt_tokens, completion_tokens
+
+
+def _call_model(prompt: str, provider: str, model: str) -> Tuple[str, int, int]:
+    if provider == "openai":
+        return _call_openai(prompt, model)
+    if provider == "anthropic":
+        return _call_anthropic(prompt, model)
+    raise ValueError(f"Unknown provider: {provider}")
+
+
+def summarize_text(text: str, provider: str = "openai", model: str | None = None) -> Tuple[str, float]:
+    """Return a short summary of the given text using the selected LLM."""
+    model = model or DEFAULT_MODELS[provider]
+    content, p_tokens, c_tokens = _call_model(
+        f"Summarize the following:\n{text}", provider, model
+    )
+    cost = _estimate_cost(p_tokens, c_tokens, provider, model)
+    return content, cost
 
 
 def generate_next_book(
@@ -29,11 +92,19 @@ def generate_next_book(
     guidance: str,
     vector_store,
     chapters: int = 10,
-) -> str:
+    provider: str = "openai",
+    model: str | None = None,
+) -> Tuple[str, float]:
     """Generate a new book continuation given existing texts and guidance."""
-    if openai is None:
-        raise ImportError("openai package is required for LLM calls")
-    summaries = [summarize_text(t) for t in existing_texts]
+    model = model or DEFAULT_MODELS[provider]
+
+    summaries = []
+    total_cost = 0.0
+    for t in existing_texts:
+        summary, cost = summarize_text(t, provider, model)
+        summaries.append(summary)
+        total_cost += cost
+
     context = "\n".join(summaries)
     prompt = (
         "You are the author continuing this saga. Keep tone and world consistent.\n"
@@ -41,8 +112,7 @@ def generate_next_book(
         f"Context from previous books: {context}\n"
         f"Write {chapters} chapters."
     )
-    response = openai.ChatCompletion.create(
-        model=MODEL,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    return response["choices"][0]["message"]["content"].strip()
+
+    content, p_tokens, c_tokens = _call_model(prompt, provider, model)
+    total_cost += _estimate_cost(p_tokens, c_tokens, provider, model)
+    return content, total_cost

--- a/ghostwriter/parser.py
+++ b/ghostwriter/parser.py
@@ -3,7 +3,7 @@
 from typing import List
 
 try:
-    from ebooklib import epub
+    from ebooklib import epub, ITEM_DOCUMENT
 except ImportError as e:  # pragma: no cover - library might not be installed
     epub = None
 
@@ -16,6 +16,6 @@ def read_epub(file_path: str) -> List[str]:
     book = epub.read_epub(file_path)
     chapters = []
     for item in book.get_items():
-        if item.get_type() == epub.ITEM_DOCUMENT:
+        if item.get_type() == ITEM_DOCUMENT:
             chapters.append(item.get_content().decode("utf-8"))
     return chapters

--- a/ghostwriter/tests/test_parser.py
+++ b/ghostwriter/tests/test_parser.py
@@ -1,0 +1,26 @@
+import tempfile
+from pathlib import Path
+
+from ghostwriter.parser import read_epub
+
+from ebooklib import epub
+
+
+def _make_epub(path: Path) -> None:
+    book = epub.EpubBook()
+    chapter = epub.EpubHtml(title='Intro', file_name='chap1.xhtml')
+    chapter.content = '<p>Hello world</p>'
+    book.add_item(chapter)
+    book.spine = ['nav', chapter]
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    epub.write_epub(str(path), book)
+
+
+def test_read_epub(tmp_path: Path) -> None:
+    file_path = tmp_path / 'book.epub'
+    _make_epub(file_path)
+    chapters = read_epub(str(file_path))
+    assert len(chapters) >= 1
+    assert any('Hello world' in ch for ch in chapters)
+

--- a/ghostwriter/wrapper.py
+++ b/ghostwriter/wrapper.py
@@ -1,0 +1,55 @@
+"""Interactive wrapper for Ghostwriter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .cli import _load_dependencies
+from .parser import read_epub
+from .llm import DEFAULT_MODELS
+
+
+def _gather_epubs(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(path.glob("*.epub"))
+    return [path]
+
+
+def main() -> None:
+    print("Ghostwriter interactive wrapper")
+    paths = input("Enter path(s) to EPUB files or directories (comma separated): ")
+    guidance = input("Enter outline/guidance for the next book: ")
+    chapters_str = input("Number of chapters [10]: ") or "10"
+    provider = input("LLM provider (openai/anthropic) [openai]: ") or "openai"
+    suggestion = DEFAULT_MODELS.get(provider, "")
+    if suggestion:
+        print(f"Suggested model: {suggestion}")
+    model = input(f"Model name [{suggestion}]: ") or suggestion
+    out = input("Output filename [next_book.txt]: ") or "next_book.txt"
+
+    VectorStore, generate_next_book = _load_dependencies()
+    store = VectorStore()
+    texts: list[str] = []
+    for p in [p.strip() for p in paths.split(',') if p.strip()]:
+        for book_path in _gather_epubs(Path(p)):
+            chapters = read_epub(str(book_path))
+            texts.extend(chapters)
+            store.add_texts(chapters)
+
+    result, cost = generate_next_book(
+        texts,
+        guidance,
+        store,
+        chapters=int(chapters_str),
+        provider=provider,
+        model=model,
+    )
+
+    Path(out).write_text(result, encoding="utf-8")
+    print(f"Book saved as {out}")
+    print(f"Estimated cost: ${cost:.4f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ebooklib
 openai
+anthropic
 numpy


### PR DESCRIPTION
## Summary
- add a wrapper module that interactively collects inputs and runs generation
- fix `read_epub` constant reference
- expose `interactive` entry point
- document wrapper usage
- add regression test for EPUB parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683cfbd11aac83268b4ddfaf1c499264